### PR TITLE
CCRSA-22 Exclude entity and DTO classes from code duplication check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <c3p0.version>5.4.20.Final</c3p0.version>
         <mariadb.jdbc.version>2.6.2</mariadb.jdbc.version>
         <sonar.coverage.exclusions>**/entity/**/*,**/dto/**/*</sonar.coverage.exclusions>
+        <sonar.cpd.exclusions>**/entity/**/*,**/dto/**/*</sonar.cpd.exclusions>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Added in `pom.xml` by property `sonar.cpd.exclusions`.
closes #22 